### PR TITLE
Made container containing the raised button width to 110

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -68,7 +68,7 @@ class _HomePageState extends State<HomePage> {
               ),
               Container( // Button
                 margin: EdgeInsets.only(top: 20),
-                width: 100,
+                width: 110,
                 height: 40,
                 child: RaisedButton(
                   child: Text(


### PR DESCRIPTION
So that change text gets in a single line on probably all devices.
As on my device the 'e' of 'change' is appearing on the next line
![Screenshot_2020-04-22-21-14-14-736_com example infodog](https://user-images.githubusercontent.com/59681238/80008460-6d0a7300-84e5-11ea-9396-ba2a8c709507.jpg)
